### PR TITLE
update FEP00: add  issue to description-table

### DIFF
--- a/FEP00.md
+++ b/FEP00.md
@@ -5,7 +5,8 @@
 | Status            | Draft / Proposed / Accepted / Rejected / Deferred / Implemented               |
 | Author(s)         | user name                                                                     |
 | Created           | Oct 15, 2019                                                                  |
-| Updated           | Dec 06, 2019                                                                  |
+| Updated           | Dec 21, 2019                                                                  |
+| Issue             | link to mantis issues which are adressed by this FEP                          |
 | Discussion        | link to the PR where the FEP is being discussed, NA is circulated initially   |
 | Implementation    | link to the PR for the implementation, NA if not availble                     |
 


### PR DESCRIPTION
We came to the conclusion that we need a section to refer to a mantis-issue [1]. Reviewing this might not make much sense as this is only an administrative change but I would like to make this repo really driven by the community so going without the reviewing process is no option.
Also if you know about a potential FEP please go ahead and try to write a proposal to see if the template already fits its purpose.

[1] https://github.com/FreeCAD/FreeCAD-Enhancement-Proposals/issues/3