### PR TITLE
Basic readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# FreeCAD-Enhancement-Proposals
+FreeCAD-Enhancement-Proposals (FEP's)
+
+Original [forum post](https://forum.freecadweb.org/viewtopic.php?f=8&t=40728).
+
+This repository is intended to contain something similar to [PEPs][peps]
+ / [CFEPs][cfeps] / [IPEPs][ipeps] / [QGISFPs][qgisfp] for the FreeCAD project.
+
+Users may raise pull-requests against this repository with their own proposals
+ along with a forum-post for more in-depth discussion.
+
+[peps]: https://www.python.org/dev/peps/
+[cfeps]: https://github.com/conda-forge/cfep
+[ipeps]: https://github.com/ipython/ipython/wiki/IPEPs:-IPython-Enhancement-Proposals
+[qgisfp]: https://github.com/qgis/QGIS-Enhancement-Proposals
+
+
+# Index of FEPs
+
+* [FEP 00: FEP Template](FEP00.md) -- 


### PR DESCRIPTION
Stumbled upon the repo, found it lacking a readme file or any link to its purpose, searched the forums to find the original thread.

It was mentioned in the thread that FEPs should replace the roadmap on the wiki; Is this still a relevant idea, has it been decided on?