### PR TITLE
Create .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,3 @@ repos:
         types: [markdown]
       - id: check-yaml
       - id: check-added-large-files
-
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: v0.13.0
-    hooks:
-      - id: markdownlint
-        files: \.md$

--- a/FEPs/FEP-0001-process/README.md
+++ b/FEPs/FEP-0001-process/README.md
@@ -62,7 +62,7 @@ for Python. Therefore, enhancement proposals are a better fit for FreeCAD than R
 Each FEP is numbered using four digits and new FEPs should get the next free FEP number. FEP numbers
 are unique and persistent - once a FEP number is obtained, it is reserved for that and only that FEP
 and cannot be reused later. All FEPs are stored in the [FEP Repository] as files within the `FEPs`
-folder. 
+folder.
 
 ### Who can create a FEP?
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ This repository contains FreeCAD Enhancement Proposals (FEPs) that are used to d
 ### Active
  - [FEP-0001: FEP Process](./FEPs/FEP-0001-process) - Definition of new FreeCAD Enhancement Process
 ### Accepted (awaiting implementation)
-### Implemented 
+### Implemented
 ### Rejected
 ### Withdrawn


### PR DESCRIPTION
So we stop getting CI failures due to this file being missing. Does only basic markdown checks.