### PR TITLE
FEP-0003: FreeCAD Release Schedule and Process - Alternative

### DIFF
--- a/FEPs/FEP-0003-release-schedule/README.md
+++ b/FEPs/FEP-0003-release-schedule/README.md
@@ -1,0 +1,135 @@
+# FEP-0003 FreeCAD Release Schedule and Process
+
+| FEP-0003       |                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------- |
+| Type           | Process                                                                                         |
+| Status         | Draft                                                                                           |
+| Author(s)      | @oursland                                                                                       |
+| Version        | 0.1                                                                                             |
+| Created        | 2025-06-24                                                                                      |
+| Updated        | 2025-06-24                                                                                      |
+| Discussion     |                                                                                                 |
+| Implementation |                                                                                                 |
+
+This FEP is to outline a planned release schedule and process that balances regularity, maintainability, and stability.
+
+## Motivation
+
+The release schedule is irregular, with many users relying upon the weekly releases to gain access to key features and fixes.  Uncertainty about when a release is to be made can make planning for upgrades, API and workbench deprecation, and support for both FreeCAD developers and 3rd party workbench and macro developers.
+
+## Rationale
+
+* Regular releases provide a basis on which users and developers may plan upgrades and feature integrations.
+* Too frequent releases can be a challenge to keep up with, whereas too infrequent releases push developers to use unstable weekly builds.
+* The more the `main` branch has deviated from a given release, the more challenging it is to backport fixes to.
+* Not all releases need to carry the same support weight, and therefore not all releases need to be considered for backports.
+* Long Term Support (LTS) designated releases shall receive support for a duration of one year after initial release.
+
+## Specification
+
+It is proposed that:
+
+* feature releases be made on a quarterly basis
+* patch releases to supported versions made monthly
+* a feature release is designated as an LTS release annually
+
+The following plot depicts the automated branching schedule and milestone releases:
+
+```mermaid
+gantt
+    title Release and Support Schedule
+    dateFormat YYYY-MM-DD
+    section 2026
+        2026.04 (LTS) :2026-01-01, 2026-01-01,2027-03-31
+        2026.04.00 :milestone, 2026-01-01, 2026-01-01
+        2026.04.01 :milestone, 2026-02-01, 2026-02-01
+        2026.04.02 :milestone, 2026-03-01, 2026-03-01
+        2026.04.03 :milestone, 2026-04-01, 2026-04-01
+        2026.04.04 :milestone, 2026-05-01, 2026-05-01
+        2026.04.05 :milestone, 2026-06-01, 2026-06-01
+        2026.04.06 :milestone, 2026-07-01, 2026-07-01
+        2026.04.07 :milestone, 2026-08-01, 2026-08-01
+        2026.04.08 :milestone, 2026-09-01, 2026-09-01
+        2026.04.09 :milestone, 2026-10-01, 2026-10-01
+        2026.04.10 :milestone, 2026-11-01, 2026-11-01
+        2026.04.11 :milestone, 2026-12-01, 2026-12-01
+        2026.04.12 :milestone, 2027-01-01, 2027-01-01
+        2026.04.13 :milestone, 2027-02-01, 2027-02-01
+        2026.04.14 :milestone, 2027-03-01, 2027-03-01
+
+        2026.07 :2026-07-01, 2026-04-01,2026-07-01
+        2026.07.00 :milestone, 2026-04-01, 2026-04-01
+        2026.07.01 :milestone, 2026-05-01, 2026-05-01
+        2026.07.02 :milestone, 2026-06-01, 2026-06-01
+        2026.07.03 :milestone, 2026-07-01, 2026-07-01
+
+        2026.10 :2026-10-01, 2026-07-01,2026-10-01
+        2026.10.00 :milestone, 2026-07-01, 2026-07-01
+        2026.10.01 :milestone, 2026-08-01, 2026-08-01
+        2026.10.02 :milestone, 2026-09-01, 2026-09-01
+        2026.10.03 :milestone, 2026-10-01, 2026-10-01
+
+    section 2027
+        2027.01 :2027-01-01, 2026-10-01,2027-01-01
+        2027.01.00 :milestone, 2026-10-01, 2026-10-01
+        2027.01.01 :milestone, 2026-11-01, 2026-11-01
+        2027.01.02 :milestone, 2026-12-01, 2026-12-01
+        2027.01.03 :milestone, 2027-01-01, 2027-01-01
+
+        2027.04 (LTS) :2027-01-01, 2027-01-01,2028-03-31
+        2027.04.00 :milestone, 2027-01-01, 2027-01-01
+        2027.04.01 :milestone, 2027-02-01, 2027-02-01
+        2027.04.02 :milestone, 2027-03-01, 2027-03-01
+        2027.04.03 :milestone, 2027-04-01, 2027-04-01
+```
+
+The following plot depicts the automated branching and cherry-picking of bugfix commits into a release branch:
+
+```mermaid
+gitGraph
+   commit id:"Feature 1"
+   commit id:"Feature 2"
+   branch "2026.04"
+   checkout main
+   commit id:"Feature 3"
+   commit id:"Feature 4"
+   commit id:"Bugfix 1"
+   checkout "2026.04"
+   cherry-pick id:"Bugfix 1"
+   checkout "main"
+   commit id:"Feature 5"
+   commit id:"Bugfix 2"
+   checkout "2026.04"
+   cherry-pick id:"Bugfix 2"
+   checkout "main"
+   commit id:"Feature 6"
+   commit id:"Feature 7"
+```
+
+### Automated Release Branching
+
+At the beginning of a release window (quarter for feature release), a release branch is created automatically through the use of a GitHub cron workflow.  At the end of the release window, the release shall be made automatically with a tag with a GitHub cron workflow, if possible, and the next window shall open.
+
+### Feature Releases
+
+A feature release is branched from `main`.  This suggests that all features intended for a release shall be merged to the `main` branch prior to the creation of the release branch.  Under normal circumstances, only bugfix patches should be cherry-picked to the release branch.  In special circumstances, a feature may be cherry-picked to the release branch, but it is a priority to ensure that this does not degrade the user experience of the release.  Only one feature release shall be supported for patch releases.  Patch releases continue for the release for a duration of one quarter.
+
+### LTS Releases
+
+The second quarter release each year shall be selected as the LTS release.  Only one LTS release shall be supported for long-term maintenance.  Patch releases continue for the LTS release for a duration of one year.
+
+### Patch Releases
+
+PRs merged to `main` may be labeled for backport.  Attempts to backport to the open release branches should be made automatically, with failures being alerted to the developers to perform the manual backporting.
+
+### Impact on existing features / subsystems
+
+This feature will require the development of some tooling to automate the release branch management and backport functionality.
+
+### Backwards Compatibility (only for Core Changes)
+
+Any remarks about how the proposed change will affect the backwards compatibility for files, addons and workflows.
+
+## License / Copyright
+
+All FEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FEPs/FEP-0003-release-schedule/README.md
+++ b/FEPs/FEP-0003-release-schedule/README.md
@@ -1,0 +1,62 @@
+# FEP-0003 FreeCAD Release Schedule and Process
+
+| FEP-0003       |                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------- |
+| Type           | Process                                                                                         |
+| Status         | Draft                                                                                           |
+| Author(s)      | @oursland                                                                                       |
+| Version        | 0.1                                                                                             |
+| Created        | 2025-06-24                                                                                      |
+| Updated        | 2025-06-24                                                                                      |
+| Discussion     |                                                                                                 |
+| Implementation |                                                                                                 |
+
+This FEP is to outline a planned release schedule and process that balances regularity, maintainability, and stability.
+
+## Motivation
+
+The release schedule is irregular, with many users relying upon the weekly releases to gain access to key features and fixes.  Uncertainty about when a release is to be made can make planning for upgrades, API and workbench deprecation, and support for both FreeCAD developers and 3rd party workbench and macro developers.
+
+## Rationale
+
+* Regular releases provide a basis on which users and developers may plan upgrades and feature integrations.
+* Too frequent releases can be a challenge to keep up with, whereas too infrequent releases push developers to use unstable weekly builds.
+* The more the `main` branch has deviated from a given release, the more challenging it is to backport fixes to.
+* Not all releases need to carry the same support weight, and therefore not all releases need to be considered for backports.
+* Long Term Support (LTS) designated releases shall receive support for a duration of one year after initial release.
+
+## Specification
+
+It is proposed that:
+
+* feature releases be made on a quarterly basis
+* patch releases to supported versions made monthly
+* a feature release is designated as an LTS release annually
+
+### Automated Release Branching
+
+At the beginning of a release window (quarter for feature release), a release branch is created automatically through the use of a GitHub cron workflow.  At the end of the release window, the release shall be made automatically with a tag with a GitHub cron workflow, if possible, and the next window shall open.
+
+### Feature Releases
+
+A feature release is branched from `main`.  This suggests that all features intended for a release shall be merged to the `main` branch prior to the creation of the release branch.  Under normal circumstances, only bugfix patches should be cherry-picked to the release branch.  In special circumstances, a feature may be cherry-picked to the release branch, but it is a priority to ensure that this does not degrade the user experience of the release.  Only one feature release shall be supported for patch releases.  Patch releases continue for the release for a duration of one quarter.
+
+### LTS Releases
+
+The second quarter release each year shall be selected as the LTS release.  Only one LTS release shall be supported for long-term maintenance.  Patch releases continue for the LTS release for a duration of one year.
+
+### Patch Releases
+
+PRs merged to `main` may be labeled for backport.  Attempts to backport to the open release branches should be made automatically, with failures being alerted to the developers to perform the manual backporting.
+
+### Impact on existing features / subsystems
+
+This feature will require the development of some tooling to automate the release branch management and backport functionality.
+
+### Backwards Compatibility (only for Core Changes)
+
+Any remarks about how the proposed change will affect the backwards compatibility for files, addons and workflows.
+
+## License / Copyright
+
+All FEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/FEPs/FEP-0003-release-schedule/README.md
+++ b/FEPs/FEP-0003-release-schedule/README.md
@@ -33,6 +33,79 @@ It is proposed that:
 * patch releases to supported versions made monthly
 * a feature release is designated as an LTS release annually
 
+The following plot depicts the automated branching schedule and milestone releases:
+
+```mermaid
+gantt
+    title Release and Support Schedule
+    dateFormat YYYY-MM-DD
+    section 2026
+        2026.04 (LTS) :2026-01-01, 2026-01-01,2027-03-31
+        2026.04.00 :milestone, 2026-01-01, 2026-01-01
+        2026.04.01 :milestone, 2026-02-01, 2026-02-01
+        2026.04.02 :milestone, 2026-03-01, 2026-03-01
+        2026.04.03 :milestone, 2026-04-01, 2026-04-01
+        2026.04.04 :milestone, 2026-05-01, 2026-05-01
+        2026.04.05 :milestone, 2026-06-01, 2026-06-01
+        2026.04.06 :milestone, 2026-07-01, 2026-07-01
+        2026.04.07 :milestone, 2026-08-01, 2026-08-01
+        2026.04.08 :milestone, 2026-09-01, 2026-09-01
+        2026.04.09 :milestone, 2026-10-01, 2026-10-01
+        2026.04.10 :milestone, 2026-11-01, 2026-11-01
+        2026.04.11 :milestone, 2026-12-01, 2026-12-01
+        2026.04.12 :milestone, 2027-01-01, 2027-01-01
+        2026.04.13 :milestone, 2027-02-01, 2027-02-01
+        2026.04.14 :milestone, 2027-03-01, 2027-03-01
+
+        2026.07 :2026-07-01, 2026-04-01,2026-07-01
+        2026.07.00 :milestone, 2026-04-01, 2026-04-01
+        2026.07.01 :milestone, 2026-05-01, 2026-05-01
+        2026.07.02 :milestone, 2026-06-01, 2026-06-01
+        2026.07.03 :milestone, 2026-07-01, 2026-07-01
+
+        2026.10 :2026-10-01, 2026-07-01,2026-10-01
+        2026.10.00 :milestone, 2026-07-01, 2026-07-01
+        2026.10.01 :milestone, 2026-08-01, 2026-08-01
+        2026.10.02 :milestone, 2026-09-01, 2026-09-01
+        2026.10.03 :milestone, 2026-10-01, 2026-10-01
+
+    section 2027
+        2027.01 :2027-01-01, 2026-10-01,2027-01-01
+        2027.01.00 :milestone, 2026-10-01, 2026-10-01
+        2027.01.01 :milestone, 2026-11-01, 2026-11-01
+        2027.01.02 :milestone, 2026-12-01, 2026-12-01
+        2027.01.03 :milestone, 2027-01-01, 2027-01-01
+
+        2027.04 (LTS) :2027-01-01, 2027-01-01,2028-03-31
+        2027.04.00 :milestone, 2027-01-01, 2027-01-01
+        2027.04.01 :milestone, 2027-02-01, 2027-02-01
+        2027.04.02 :milestone, 2027-03-01, 2027-03-01
+        2027.04.03 :milestone, 2027-04-01, 2027-04-01
+```
+
+The following plot depicts the automated branching and cherry-picking of bugfix commits into a release branch:
+
+```mermaid
+gitGraph
+   commit id:"Feature 1"
+   commit id:"Feature 2"
+   branch "2026.04"
+   checkout main
+   commit id:"Feature 3"
+   commit id:"Feature 4"
+   commit id:"Bugfix 1"
+   checkout "2026.04"
+   cherry-pick id:"Bugfix 1"
+   checkout "main"
+   commit id:"Feature 5"
+   commit id:"Bugfix 2"
+   checkout "2026.04"
+   cherry-pick id:"Bugfix 2"
+   checkout "main"
+   commit id:"Feature 6"
+   commit id:"Feature 7"
+```
+
 ### Automated Release Branching
 
 At the beginning of a release window (quarter for feature release), a release branch is created automatically through the use of a GitHub cron workflow.  At the end of the release window, the release shall be made automatically with a tag with a GitHub cron workflow, if possible, and the next window shall open.

--- a/FEPs/FEP-0003-release-schedule/README.md
+++ b/FEPs/FEP-0003-release-schedule/README.md
@@ -1,134 +1,172 @@
 # FEP-0003 FreeCAD Release Schedule and Process
 
-| FEP-0003       |                                                                                                 |
-| -------------- | ----------------------------------------------------------------------------------------------- |
-| Type           | Process                                                                                         |
-| Status         | Draft                                                                                           |
-| Author(s)      | @oursland                                                                                       |
-| Version        | 0.1                                                                                             |
-| Created        | 2025-06-24                                                                                      |
-| Updated        | 2025-06-24                                                                                      |
-| Discussion     |                                                                                                 |
-| Implementation |                                                                                                 |
+| FEP-0003       |                                      |
+| -------------- | ------------------------------------ |
+| Type           | Process                              |
+| Status         | Draft                                |
+| Author(s)      | @oursland, Kacper Donat (@kadet1090) |
+| Version        | 0.2                                  |
+| Created        | 2025-06-24                           |
+| Updated        | 2026-04-11                           |
+| Discussion     |                                      |
+| Implementation |                                      |
 
-This FEP is to outline a planned release schedule and process that balances regularity, maintainability, and stability.
+## Abstract
+
+This FEP proposes a structured release schedule for FreeCAD consisting of three releases per year,
+one of which is designated as a Long-Term Support (LTS) release. It defines fixed branching dates,
+a stabilization period following each branch, a Release Candidate (RC) cycle, and distinct
+policies for LTS vs. normal releases.
 
 ## Motivation
 
-The release schedule is irregular, with many users relying upon the weekly releases to gain access to key features and fixes.  Uncertainty about when a release is to be made can make planning for upgrades, API and workbench deprecation, and support for both FreeCAD developers and 3rd party workbench and macro developers.
+The current release schedule is irregular, with many users relying on weekly builds to access
+key features and fixes. Uncertainty about release timing makes planning difficult for users,
+third-party workbench developers, macro authors, and downstream distributors. A predictable
+cadence reduces pressure to prematurely merge features, allows smaller and more manageable
+releases, and gives contributors a clear rhythm to work with.
 
 ## Rationale
 
-* Regular releases provide a basis on which users and developers may plan upgrades and feature integrations.
-* Too frequent releases can be a challenge to keep up with, whereas too infrequent releases push developers to use unstable weekly builds.
-* The more the `main` branch has deviated from a given release, the more challenging it is to backport fixes to.
-* Not all releases need to carry the same support weight, and therefore not all releases need to be considered for backports.
-* Long Term Support (LTS) designated releases shall receive support for a duration of one year after initial release.
+- Regular releases provide a basis on which users and developers may plan upgrades and feature
+  integrations.
+- Too frequent releases can be a challenge to keep up with, whereas too infrequent releases push
+  users to rely on unstable weekly builds.
+- Three releases per year balances development velocity with the capacity of a volunteer-driven
+  project.
+- An LTS release once per year provides a stable target for professional users and organizations. It also aims to fix shortcomings of normal releases.
+- Short, well-defined stabilization windows keep the project focused without long feature freezes
+  that stall contributor momentum.
 
 ## Specification
 
-It is proposed that:
+### Release Cadence
 
-* feature releases be made on a quarterly basis
-* patch releases to supported versions made monthly
-* a feature release is designated as an LTS release annually
+FreeCAD shall produce three releases per year on a fixed schedule. One of these shall be
+designated the LTS release.
 
-The following plot depicts the automated branching schedule and milestone releases:
+Each release kind should get one patch release per month. For now the process shall remain manual
+but the automation should be considered at a later date without need of separate FEP. If no backport was made since last patch release - the release is skipped.
 
-```mermaid
-gantt
-    title Release and Support Schedule
-    dateFormat YYYY-MM-DD
-    section 2026
-        2026.04 (LTS) :2026-01-01, 2026-01-01,2027-03-31
-        2026.04.00 :milestone, 2026-01-01, 2026-01-01
-        2026.04.01 :milestone, 2026-02-01, 2026-02-01
-        2026.04.02 :milestone, 2026-03-01, 2026-03-01
-        2026.04.03 :milestone, 2026-04-01, 2026-04-01
-        2026.04.04 :milestone, 2026-05-01, 2026-05-01
-        2026.04.05 :milestone, 2026-06-01, 2026-06-01
-        2026.04.06 :milestone, 2026-07-01, 2026-07-01
-        2026.04.07 :milestone, 2026-08-01, 2026-08-01
-        2026.04.08 :milestone, 2026-09-01, 2026-09-01
-        2026.04.09 :milestone, 2026-10-01, 2026-10-01
-        2026.04.10 :milestone, 2026-11-01, 2026-11-01
-        2026.04.11 :milestone, 2026-12-01, 2026-12-01
-        2026.04.12 :milestone, 2027-01-01, 2027-01-01
-        2026.04.13 :milestone, 2027-02-01, 2027-02-01
-        2026.04.14 :milestone, 2027-03-01, 2027-03-01
+### Branching Dates
 
-        2026.07 :2026-07-01, 2026-04-01,2026-07-01
-        2026.07.00 :milestone, 2026-04-01, 2026-04-01
-        2026.07.01 :milestone, 2026-05-01, 2026-05-01
-        2026.07.02 :milestone, 2026-06-01, 2026-06-01
-        2026.07.03 :milestone, 2026-07-01, 2026-07-01
+Release branches are created on the following fixed dates each year:
 
-        2026.10 :2026-10-01, 2026-07-01,2026-10-01
-        2026.10.00 :milestone, 2026-07-01, 2026-07-01
-        2026.10.01 :milestone, 2026-08-01, 2026-08-01
-        2026.10.02 :milestone, 2026-09-01, 2026-09-01
-        2026.10.03 :milestone, 2026-10-01, 2026-10-01
+| Branch Date  | Release Type |
+| ------------ | ------------ |
+| 31 May       | Normal       |
+| 30 September | Normal       |
+| 31 January   | LTS          |
 
-    section 2027
-        2027.01 :2027-01-01, 2026-10-01,2027-01-01
-        2027.01.00 :milestone, 2026-10-01, 2026-10-01
-        2027.01.01 :milestone, 2026-11-01, 2026-11-01
-        2027.01.02 :milestone, 2026-12-01, 2026-12-01
-        2027.01.03 :milestone, 2027-01-01, 2027-01-01
+Releases for normal types are expected to happen within 4-6 weeks period after branching with 2-3 RC release candidates. LTS release can take a bit more time due to more strict requirements in terms of stability.
 
-        2027.04 (LTS) :2027-01-01, 2027-01-01,2028-03-31
-        2027.04.00 :milestone, 2027-01-01, 2027-01-01
-        2027.04.01 :milestone, 2027-02-01, 2027-02-01
-        2027.04.02 :milestone, 2027-03-01, 2027-03-01
-        2027.04.03 :milestone, 2027-04-01, 2027-04-01
-```
+### Stabilization Period
 
-The following plot depicts the automated branching and cherry-picking of bugfix commits into a release branch:
+Following each branching date, a stabilization period of two to four weeks begins. During this
+period, the focus shifts primarily to the newly created release branch: resolving blockers,
+fixing regressions, and preparing release candidates.
 
-```mermaid
-gitGraph
-   commit id:"Feature 1"
-   commit id:"Feature 2"
-   branch "2026.04"
-   checkout main
-   commit id:"Feature 3"
-   commit id:"Feature 4"
-   commit id:"Bugfix 1"
-   checkout "2026.04"
-   cherry-pick id:"Bugfix 1"
-   checkout "main"
-   commit id:"Feature 5"
-   commit id:"Bugfix 2"
-   checkout "2026.04"
-   cherry-pick id:"Bugfix 2"
-   checkout "main"
-   commit id:"Feature 6"
-   commit id:"Feature 7"
-```
+- The goal is to resolve all blockers within the stabilization period and produce an RC by its end.
+- If blockers remain unresolved at the end of the stabilization period, an RC is still published
+  so that the full picture of outstanding issues is visible to contributors and users.
+- After the stabilization period, `main` resumes normal development using the same merge process
+  as today.
 
-### Automated Release Branching
+### Release Candidate Cycle
 
-At the beginning of a release window (quarter for feature release), a release branch is created automatically through the use of a GitHub cron workflow.  At the end of the release window, the release shall be made automatically with a tag with a GitHub cron workflow, if possible, and the next window shall open.
+- The first RC is published at or before the end of the stabilization period.
+- Subsequent RCs follow a two-week schedule.
+- UI freeze begins with the first RC and applies to all active release branches.
 
-### Feature Releases
+### Normal Releases
 
-A feature release is branched from `main`.  This suggests that all features intended for a release shall be merged to the `main` branch prior to the creation of the release branch.  Under normal circumstances, only bugfix patches should be cherry-picked to the release branch.  In special circumstances, a feature may be cherry-picked to the release branch, but it is a priority to ensure that this does not degrade the user experience of the release.  Only one feature release shall be supported for patch releases.  Patch releases continue for the release for a duration of one quarter.
+- Normal releases aim to ship after the third RC.
+- Release managers evaluate outstanding blockers and may, in exceptional cases, postpone a fix
+  to the next release if it is not critical. Blockers resulting in data loss cannot be postponed.
+- There is no strict feature freeze on `main` during normal release windows.
 
 ### LTS Releases
 
-The second quarter release each year shall be selected as the LTS release.  Only one LTS release shall be supported for long-term maintenance.  Patch releases continue for the LTS release for a duration of one year.
+- The LTS release window applies a light feature freeze: the focus is on bug fixes, stability
+  improvements, and completing work that was not resolved in previous normal releases.
+- Lower-risk features may be accepted, but the emphasis is on quality and stability rather than
+  new functionality.
+- All release blockers must be addressed before an LTS release ships: either fixed or explicitly
+  unmarked as blockers with documented rationale.
 
-### Patch Releases
+### Backport Policy
 
-PRs merged to `main` may be labeled for backport.  Attempts to backport to the open release branches should be made automatically, with failures being alerted to the developers to perform the manual backporting.
+Each release is supported until the next release of the same kind is branched. This means backports target at most two active branches at any time (the latest normal release branch and the latest LTS release branch). Under normal circumstances, only bugfix patches should be cherry-picked to the release branch.  In special circumstances, a feature may be cherry-picked to the release branch, but it is a priority to ensure that this does not degrade the user experience of the release.
+
+Backporting is aided by tooling such as
+[`backport-action`](https://github.com/korthout/backport-action): maintainers label PRs
+for backporting and the tooling cherry-picks them to the appropriate branches automatically. Contributors may aid maintainers with the choice by explicitly asking for backport.
+
+### Example Schedule
+
+```mermaid
+gantt
+  title Release and Support Schedule
+  dateFormat YYYY-MM-DD
+  axisFormat %b %Y
+
+  section main
+  Ongoing development :active, 2026-01-01, 2027-06-30
+
+  section releases/FreeCAD-1.2-lts
+  Stabilization          :2026-01-31, 2026-02-21
+  RC cycle               :2026-02-21, 2026-03-21
+  1.2.0 (lts)            :milestone, 2026-03-21, 0d
+  1.2.1 (lts)            :milestone, 2026-04-21, 0d
+  1.2.2 (lts)            :milestone, 2026-05-21, 0d
+  1.2.3 (lts)            :milestone, 2026-06-21, 0d
+  1.2.4 (lts)            :milestone, 2026-07-21, 0d
+  1.2.5 (lts)            :milestone, 2026-08-21, 0d
+  1.2.6 (lts)            :milestone, 2026-09-21, 0d
+  1.2.7 (lts)            :milestone, 2026-10-21, 0d
+  1.2.8 (lts)            :milestone, 2026-11-21, 0d
+  1.2.9 (lts)            :milestone, 2026-12-21, 0d
+  1.2.10 (lts)           :milestone, 2027-01-21, 0d
+
+  section releases/FreeCAD-1.3
+  Stabilization          :2026-05-31, 2026-06-21
+  RC cycle               :2026-06-21, 2026-07-19
+  1.3.0                  :milestone, 2026-07-19, 0d
+  1.3.1                  :milestone, 2026-08-19, 0d
+  1.3.2                  :milestone, 2026-09-19, 0d
+
+  section releases/FreeCAD-1.4
+  Stabilization          :2026-09-30, 2026-10-21
+  1.4.0                  :milestone, 2026-12-18, 0d
+  1.4.1                  :milestone, 2026-12-18, 0d
+  1.4.2                  :milestone, 2027-01-18, 0d
+```
 
 ### Impact on existing features / subsystems
 
-This feature will require the development of some tooling to automate the release branch management and backport functionality.
+This FEP will put additional strain on Release Manager due to increased release frequency. Most of the work can be automated after the proposal is successfully implemented and validated.
 
-### Backwards Compatibility (only for Core Changes)
+## Further Work (optional)
 
-Any remarks about how the proposed change will affect the backwards compatibility for files, addons and workflows.
+### Change to versioning scheme
+
+This proposal does not specify a versioning scheme. CalVer (e.g. `26.1`) is a natural fit
+for a date-anchored release cycle and is recommended, but the choice of versioning scheme is
+left to a separate FEP or amendment to this one.
+
+### Automated Branching
+
+Release branches can be created automatically via a GitHub cron workflow on each branching date.
+Automatic tagging and release shall only occur when no open blocker issues are present on the
+release branch.
+
+This can be done after we validate and stabilize the proposal and shall not be considered as change requiring separate FEP.
+
+## References
+
+- [Blender release cycle](https://www.blender.org/download/releases/)
+- [QGIS release roadmap](https://qgis.org/resources/roadmap/)
+- [`backport-action`](https://github.com/korthout/backport-action)
 
 ## License / Copyright
 

--- a/FEPs/FEP-0003-release-schedule/README.md
+++ b/FEPs/FEP-0003-release-schedule/README.md
@@ -5,18 +5,18 @@
 | Type           | Process                              |
 | Status         | Draft                                |
 | Author(s)      | @oursland, Kacper Donat (@kadet1090) |
-| Version        | 0.2                                  |
+| Version        | 0.3                                  |
 | Created        | 2025-06-24                           |
-| Updated        | 2026-04-11                           |
+| Updated        | 2026-05-15                           |
 | Discussion     |                                      |
 | Implementation |                                      |
 
 ## Abstract
 
-This FEP proposes a structured release schedule for FreeCAD consisting of three releases per year,
-one of which is designated as a Long-Term Support (LTS) release. It defines fixed branching dates,
-a stabilization period following each branch, a Release Candidate (RC) cycle, and distinct
-policies for LTS vs. normal releases.
+This FEP proposes a structured release schedule for FreeCAD consisting of three releases per year.
+One of these is designated as the quality-focused release with a light feature freeze applied
+before branching. It defines fixed branching dates, a CalVer-based versioning scheme,
+a stabilization period following each branch, and a Release Candidate (RC) cycle.
 
 ## Motivation
 
@@ -34,31 +34,61 @@ releases, and gives contributors a clear rhythm to work with.
   users to rely on unstable weekly builds.
 - Three releases per year balances development velocity with the capacity of a volunteer-driven
   project.
-- An LTS release once per year provides a stable target for professional users and organizations. It also aims to fix shortcomings of normal releases.
+- A quality-focused release once per year -- without any long-term support commitment -- provides
+  a stable and well-polished target for users who prioritize reliability.
 - Short, well-defined stabilization windows keep the project focused without long feature freezes
   that stall contributor momentum.
 
 ## Specification
 
+### Versioning Scheme
+
+FreeCAD shall adopt a CalVer-based versioning scheme of the form `YY.N`, where:
+
+- `YY` is the two-digit year of the `.1` quality-focused release (i.e., the year of the
+  January branch).
+- `N` is the sequential release number within that cycle (1, 2, or 3).
+
+Patch releases append a third component: `YY.N.P` (e.g. `27.1.1`).
+
+The first release under this scheme is `26.3`, branched on 30 September 2026. The first
+quality-focused release is `27.1`, branched on 31 January 2027. Each subsequent cycle begins
+on 31 January of the following year.
+
+Examples: `26.3`, `27.1`, `27.2`, `27.3`, `28.1`, `28.2`, `28.3`.
+
 ### Release Cadence
 
-FreeCAD shall produce three releases per year on a fixed schedule. One of these shall be
-designated the LTS release.
+FreeCAD shall produce three releases per year on a fixed schedule. One of these -- the `.1`
+release — is designated as the quality-focused release.
 
-Each release kind should get one patch release per month. For now the process shall remain manual
-but the automation should be considered at a later date without need of separate FEP. If no backport was made since last patch release - the release is skipped.
+Each release should get one patch release per month. For now the process shall remain manual,
+but automation should be considered at a later date without need of a separate FEP. If no
+backport was made since the last patch release, the patch release is skipped.
 
 ### Branching Dates
 
 Release branches are created on the following fixed dates each year:
 
-| Branch Date  | Release Type |
-| ------------ | ------------ |
-| 31 May       | Normal       |
-| 30 September | Normal       |
-| 31 January   | LTS          |
+| Branch Date  | Release | Type            |
+| ------------ | ------- | --------------- |
+| 31 January   | YY.1    | Quality-Focused |
+| 31 May       | YY.2    | Normal          |
+| 30 September | YY.3    | Normal          |
 
-Releases for normal types are expected to happen within 4-6 weeks period after branching with 2-3 RC release candidates. LTS release can take a bit more time due to more strict requirements in terms of stability.
+Releases are expected to ship within 4–6 weeks after branching, with 2-3 release candidates.
+
+### Light Feature Freeze
+
+In the four weeks preceding the `31 January` branching date, a light feature freeze applies
+to `main`:
+
+- Only improvements to already-merged work, bug fixes, and lower-risk features are accepted.
+- Large or speculative new features should be postponed to the next cycle.
+- The goal is that the `.1` quality-focused branch starts in a cleaner, more coherent state.
+
+A public announcement is made at the start of this light freeze to inform contributors and
+workbench developers.
 
 ### Stabilization Period
 
@@ -85,22 +115,38 @@ fixing regressions, and preparing release candidates.
   to the next release if it is not critical. Blockers resulting in data loss cannot be postponed.
 - There is no strict feature freeze on `main` during normal release windows.
 
-### LTS Releases
+### Quality-Focused Release
 
-- The LTS release window applies a light feature freeze: the focus is on bug fixes, stability
-  improvements, and completing work that was not resolved in previous normal releases.
-- Lower-risk features may be accepted, but the emphasis is on quality and stability rather than
-  new functionality.
-- All release blockers must be addressed before an LTS release ships: either fixed or explicitly
+- The quality-focused release (`.1`) applies a light feature freeze on `main` in the four weeks
+  before the branching date (see [Light Feature Freeze](#light-feature-freeze)).
+- On the release branch, the focus is on bug fixes, stability improvements, and completing work
+  that was not resolved in previous releases.
+- Lower-risk features may be accepted on the branch, but the emphasis is on quality and
+  coherence rather than new functionality.
+- All release blockers must be addressed before the release ships: either fixed or explicitly
   unmarked as blockers with documented rationale.
+- The quality-focused release carries no long-term support commitment. It is not an LTS release
+  although in rare cases it may receive additional patches.
 
 ### Backport Policy
 
-Each release is supported until the next release of the same kind is branched. This means backports target at most two active branches at any time (the latest normal release branch and the latest LTS release branch). Under normal circumstances, only bugfix patches should be cherry-picked to the release branch.  In special circumstances, a feature may be cherry-picked to the release branch, but it is a priority to ensure that this does not degrade the user experience of the release.
+Each release is supported until the next release branches. Only one release branch is actively
+maintained at any time. Under normal circumstances, only bugfix patches should be cherry-picked
+to the release branch. In special circumstances, a feature may be cherry-picked, but it must
+not degrade the user experience of the release.
 
 Backporting is aided by tooling such as
 [`backport-action`](https://github.com/korthout/backport-action): maintainers label PRs
-for backporting and the tooling cherry-picks them to the appropriate branches automatically. Contributors may aid maintainers with the choice by explicitly asking for backport.
+for backporting and the tooling cherry-picks them to the appropriate branches automatically.
+Contributors may aid maintainers with the choice by explicitly asking for a backport.
+
+### Transition Plan
+
+Following acceptance of this FEP, an announcement shall be made to inform contributors and
+the wider community of the new release schedule. The first branch under this scheme is
+`releases/26.3`, created on **30 September 2026**. This is a normal release; no light freeze
+applies before it. The first quality-focused release is `27.1`, branched on **31 January 2027**,
+with a light freeze announcement preceding that date by four weeks (around **1 January 2027**).
 
 ### Example Schedule
 
@@ -111,56 +157,66 @@ gantt
   axisFormat %b %Y
 
   section main
-  Ongoing development :active, 2026-01-01, 2027-06-30
+  Ongoing development       :active, 2026-08-01, 2028-06-30
+  Light freeze (27.1)       :2027-01-01, 2027-01-31
 
-  section releases/FreeCAD-1.2-lts
-  Stabilization          :2026-01-31, 2026-02-21
-  RC cycle               :2026-02-21, 2026-03-21
-  1.2.0 (lts)            :milestone, 2026-03-21, 0d
-  1.2.1 (lts)            :milestone, 2026-04-21, 0d
-  1.2.2 (lts)            :milestone, 2026-05-21, 0d
-  1.2.3 (lts)            :milestone, 2026-06-21, 0d
-  1.2.4 (lts)            :milestone, 2026-07-21, 0d
-  1.2.5 (lts)            :milestone, 2026-08-21, 0d
-  1.2.6 (lts)            :milestone, 2026-09-21, 0d
-  1.2.7 (lts)            :milestone, 2026-10-21, 0d
-  1.2.8 (lts)            :milestone, 2026-11-21, 0d
-  1.2.9 (lts)            :milestone, 2026-12-21, 0d
-  1.2.10 (lts)           :milestone, 2027-01-21, 0d
+  section releases/26.3
+  Stabilization             :2026-09-30, 2026-10-21
+  RC cycle                  :2026-10-21, 2026-11-18
+  26.3.0                    :milestone, 2026-11-18, 0d
+  26.3.1                    :milestone, 2026-12-18, 0d
+  26.3.2                    :milestone, 2027-01-18, 0d
 
-  section releases/FreeCAD-1.3
-  Stabilization          :2026-05-31, 2026-06-21
-  RC cycle               :2026-06-21, 2026-07-19
-  1.3.0                  :milestone, 2026-07-19, 0d
-  1.3.1                  :milestone, 2026-08-19, 0d
-  1.3.2                  :milestone, 2026-09-19, 0d
+  section releases/27.1
+  Stabilization             :2027-01-31, 2027-02-21
+  RC cycle                  :2027-02-21, 2027-03-21
+  27.1.0 (quality-focused)  :milestone, 2027-03-21, 0d
+  27.1.1                    :milestone, 2027-04-21, 0d
+  27.1.2                    :milestone, 2027-05-21, 0d
 
-  section releases/FreeCAD-1.4
-  Stabilization          :2026-09-30, 2026-10-21
-  1.4.0                  :milestone, 2026-12-18, 0d
-  1.4.1                  :milestone, 2026-12-18, 0d
-  1.4.2                  :milestone, 2027-01-18, 0d
+  section releases/27.2
+  Stabilization             :2027-05-31, 2027-06-21
+  RC cycle                  :2027-06-21, 2027-07-19
+  27.2.0                    :milestone, 2027-07-19, 0d
+  27.2.1                    :milestone, 2027-08-19, 0d
+  27.2.2                    :milestone, 2027-09-19, 0d
+
+  section releases/27.3
+  Stabilization             :2027-09-30, 2027-10-21
+  RC cycle                  :2027-10-21, 2027-11-18
+  27.3.0                    :milestone, 2027-11-18, 0d
+  27.3.1                    :milestone, 2027-12-18, 0d
+  27.3.2                    :milestone, 2028-01-18, 0d
+
+  section releases/28.1
+  Stabilization             :2028-01-31, 2028-02-21
+  RC cycle                  :2028-02-21, 2028-03-21
+  28.1.0 (quality-focused)  :milestone, 2028-03-21, 0d
 ```
 
 ### Impact on existing features / subsystems
 
-This FEP will put additional strain on Release Manager due to increased release frequency. Most of the work can be automated after the proposal is successfully implemented and validated.
+This FEP will put additional strain on Release Manager due to increased release frequency.
+Most of the work can be automated after the proposal is successfully implemented and validated.
+Switching to CalVer requires existing references to FreeCAD versioning to be updated
+in documentation and tooling.
 
 ## Further Work (optional)
 
-### Change to versioning scheme
+### Blocker Definition
 
-This proposal does not specify a versioning scheme. CalVer (e.g. `26.1`) is a natural fit
-for a date-anchored release cycle and is recommended, but the choice of versioning scheme is
-left to a separate FEP or amendment to this one.
+This proposal does not define what constitutes a "blocker" issue. A narrow, well-agreed
+definition would reduce the risk of prolonged stabilization periods. Defining blocker criteria
+is deferred to a separate FEP or amendment to avoid stalling adoption of this schedule.
 
-### Automated Branching
+### Automated Branching and Releasing
 
 Release branches can be created automatically via a GitHub cron workflow on each branching date.
 Automatic tagging and release shall only occur when no open blocker issues are present on the
 release branch.
 
-This can be done after we validate and stabilize the proposal and shall not be considered as change requiring separate FEP.
+This can be done after we validate and stabilize the proposal and shall not be considered a
+change requiring a separate FEP.
 
 ## References
 

--- a/FEPs/FEP-0003-release-schedule/README.md
+++ b/FEPs/FEP-0003-release-schedule/README.md
@@ -3,13 +3,13 @@
 | FEP-0003       |                                      |
 | -------------- | ------------------------------------ |
 | Type           | Process                              |
-| Status         | Draft                                |
+| Status         | Active                               |
 | Author(s)      | @oursland, Kacper Donat (@kadet1090) |
-| Version        | 0.3                                  |
+| Version        | 1.0                                  |
 | Created        | 2025-06-24                           |
 | Updated        | 2026-05-15                           |
-| Discussion     |                                      |
-| Implementation |                                      |
+| Discussion     | 2026-05-16                           |
+| Implementation | 2026-06-07                           |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ See Proposal [FEP-0001: FEP Process](./FEPs/FEP-0001-process/README.md) for a co
 ## FEPs
 ### Proposed
  - [FEP-0002: Asynchronous Document Recompute and Multithreading Infrastructure](https://github.com/tritao/FreeCAD-Enhancement-Proposals/blob/patch-1/FEPs/FEP-0002-async-document-recompute/README.md)
- - [FEP-0003: FreeCAD Release Schedule and Process - Alternative](https://github.com/kadet1090/FreeCAD-Enhancement-Proposals/blob/pull-16/FEPs/FEP-0003-release-schedule/README.md)
  - [FEP-0008: Project Group Structure](https://github.com/kadet1090/FreeCAD-Enhancement-Proposals/blob/groups-in-freecad/FEPs/FEP-0008-project-group-structure/README.md)
 ### Draft
- - [FEP-0003: FreeCAD Release Schedule and Process](https://github.com/oursland/FreeCAD-Enhancement-Proposals/blob/FEP-0002/FEPs/FEP-0003-release-schedule/README.md)
+ - [FEP-0003: FreeCAD Release Schedule and Process](./FEPs/FEP-0003-release-schedule/README.md) - ## Abstract
  - [FEP-0004: Python API Versioning.](https://github.com/oursland/FreeCAD-Enhancement-Proposals/blob/FEP-0003/FEPs/FEP-0004-python-api-versioning/README.md)
  - [FEP-0005: Dependency and Platform Policy](https://github.com/hyarion/FreeCAD-Enhancement-Proposals/blob/dependency-policy/FEPs/FEP-0005-process/README.md)
  - [FEP-0009: Sketch references (External Geometry & Attachment Supports) across Bodies and Parts](https://github.com/wsteffe/FreeCAD-Enhancement-Proposals/blob/FEP-00XX-partdesign-multibody-unified-cs/FEPs/FEP-0009-extendedSketchReferences/README.md)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ See Proposal [FEP-0001: FEP Process](./FEPs/FEP-0001-process/README.md) for a co
  - [FEP-0002: Asynchronous Document Recompute and Multithreading Infrastructure](https://github.com/tritao/FreeCAD-Enhancement-Proposals/blob/patch-1/FEPs/FEP-0002-async-document-recompute/README.md)
  - [FEP-0008: Project Group Structure](https://github.com/kadet1090/FreeCAD-Enhancement-Proposals/blob/groups-in-freecad/FEPs/FEP-0008-project-group-structure/README.md)
 ### Draft
- - [FEP-0003: FreeCAD Release Schedule and Process](./FEPs/FEP-0003-release-schedule/README.md) - ## Abstract
  - [FEP-0004: Python API Versioning.](https://github.com/oursland/FreeCAD-Enhancement-Proposals/blob/FEP-0003/FEPs/FEP-0004-python-api-versioning/README.md)
  - [FEP-0005: Dependency and Platform Policy](https://github.com/hyarion/FreeCAD-Enhancement-Proposals/blob/dependency-policy/FEPs/FEP-0005-process/README.md)
  - [FEP-0009: Sketch references (External Geometry & Attachment Supports) across Bodies and Parts](https://github.com/wsteffe/FreeCAD-Enhancement-Proposals/blob/FEP-00XX-partdesign-multibody-unified-cs/FEPs/FEP-0009-extendedSketchReferences/README.md)
  - [FEP-0011: Generic Collaboration Framework](https://github.com/pieterhijma/FreeCAD-Enhancement-Proposals/blob/generic-collaboration-framework/FEPs/FEP-0011-generic-collaboration-framework/README.md)
 ### Active
  - [FEP-0001: FEP Process](./FEPs/FEP-0001-process/README.md) - Definition of the FreeCAD Enhancement Process
+ - [FEP-0003: FreeCAD Release Schedule and Process](./FEPs/FEP-0003-release-schedule/README.md) - ## Abstract
  - [FEP-0007: Consistent Language Across FreeCAD](./FEPs/FEP-0007-consistent-language/README.md) - This document defines consistent rules for user-facing text in FreeCAD: menu items, toolbars, dialogs, tooltips, input hints, and other strings.
 ### Accepted (awaiting implementation)
  - [FEP-0006: Materials Editor](./FEPs/FEP-0006-materials-editor/README.md) - Rework of the materials editor to improve usability.


### PR DESCRIPTION
This is alternative version of https://github.com/FreeCAD/FreeCAD-Enhancement-Proposals/pull/16 

This FEP proposes a structured release schedule for FreeCAD consisting of three releases per year, one of which is designated as a Long-Term Support (LTS) release. It defines fixed branching dates, a stabilization period following each branch, a Release Candidate (RC) cycle, and distinct policies for LTS vs. normal releases.


### Important Links
- :mag: **rendered proposal**: [FEP-0003: FreeCAD Release Schedule and Process](https://github.com/kadet1090/FreeCAD-Enhancement-Proposals/blob/pull-16/FEPs/FEP-0003-release-schedule/README.md)
